### PR TITLE
bug fix: encode error when the second byte is even

### DIFF
--- a/src/org/arrowfield/Base32.java
+++ b/src/org/arrowfield/Base32.java
@@ -136,7 +136,7 @@ public class Base32 {
 		case 'i':
 		case 'o':
 		}
-		return -1;
+		return 0;
 	}
 
 	/**
@@ -174,7 +174,7 @@ public class Base32 {
 		case 1:
 			return new String(Arrays.copyOf(result, result.length - 6));
 		case 2:
-			return new String(Arrays.copyOf(result, result.length - 5));
+			return new String(Arrays.copyOf(result, result.length - 4));
 		case 3:
 			return new String(Arrays.copyOf(result, result.length - 3));
 		case 4:
@@ -221,9 +221,9 @@ public class Base32 {
 		case 2:
 			return Arrays.copyOf(result, result.length - 4);
 		case 3:
-			return Arrays.copyOf(result, result.length - 3);
-		case 4:
 			return null;
+		case 4:
+			return Arrays.copyOf(result, result.length - 3);
 		case 5:
 			return Arrays.copyOf(result, result.length - 2);
 		case 6:


### PR DESCRIPTION
before fix:
encode "90" to "HE2", and decode "HE2" to "91", also "9b" to "9c"
test code: https://glot.io/snippets/gg7g7r39wf

after fix:
encode "90" to "HE2A", and decode "HE2A" to "90".
test code: https://glot.io/snippets/gg7g7u7oue